### PR TITLE
Convert various line breaks to the Slack's ones

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm" # See documentation for possible values
+    directory: "/" # Location of package manifests
+    schedule:
+      interval: "weekly"

--- a/index.js
+++ b/index.js
@@ -2,9 +2,10 @@ const core = require('@actions/core');
 const slackifyMarkdown = require('slackify-markdown');
 
 try {
-    const md = core.getInput('text', {required: true});
-    const mrkdwn = slackifyMarkdown(md);
-    core.setOutput("text", mrkdwn);
+    const input = core.getInput('text', { required: true });
+    const mrkdwn = slackifyMarkdown(input);
+    const output = mrkdwn.replace(/\r\n|\r|\n/g, "\\n");
+    core.setOutput("text", output);
 } catch (error) {
     core.setFailed(error.message);
 }


### PR DESCRIPTION
## ℹ️ About

<!-- Describe your changes here ;) -->
I've tested my solution to https://github.com/LoveToKnow/slackify-markdown-action/issues/8.
Then I substitute LoveToKnow/slackify-markdown-action Slack API works.
 
 ```yaml
    - id: convertTextSlackReady
      if: steps.install.outputs.error == 0 &&  steps.restore.outputs.error == 0
      uses: denis-trofimov/slackify-markdown-action@v0.1.0
      with:
        text: ${{ steps.readyMessage.outputs.message }}

    - name: Slack links list
      if: steps.install.outputs.error == 0 &&  steps.restore.outputs.error == 0
      uses: slackapi/slack-github-action@v1.24.0
      with:
        channel-id: ${{ inputs.slack_channel_id }}
        payload: |
          {
            "text": "Your Huma server API is ready to use.",
            "blocks": [
              {
                "type": "section",
                "text": {
                  "type": "mrkdwn",
                  "text": "${{ steps.convertTextSlackReady.outputs.text }}"
                }
              }
            ]
          }
      env:
        SLACK_BOT_TOKEN: ${{ inputs.slack_bot_token }}
```

---

- [ ] Has 🧪 tests
- [ ] Has 📖 documentation

<!-- Add the link to the Jira ticket inside the parentheses -->

- [🎫 Related Ticket]()

<!-- Remember you can override this template by creating a `.github/PULL_REQUEST_TEMPLATE.md` in your repository. The template you're seeing is in the https://github.com/LoveToKnow/.github repository -->
