### PR TITLE
fix: Set semantic version to 19

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,6 +63,7 @@ jobs:
         id: release
         uses: cycjimmy/semantic-release-action@v2
         with:
+          semantic_version: 19       
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git


### PR DESCRIPTION
## ℹ️ About

Release Failed due to this [error](https://github.com/LoveToKnow/slackify-markdown-action/actions/runs/5071328001) and it seems that  `cycjimmy/semantic-release-action` release notes contains breaking changes related to ESM-only and minimum Node.js 18[[Source](https://github.com/cycjimmy/semantic-release-action/issues/143)].  


---

- [ ] Has 🧪 tests
- [ ] Has 📖 documentation

<!-- Add the link to the Jira ticket inside the parentheses -->

- [🎫 Related Ticket]()

<!-- Remember you can override this template by creating a `.github/PULL_REQUEST_TEMPLATE.md` in your repository. The template you're seeing is in the https://github.com/LoveToKnow/.github repository -->
