### PR TITLE
feat: Add input variable to stringify result

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,10 @@ GitHub Action to convert markdown into Slack's mrkdwn. Basically just a wrapper 
 ### Inputs
 
 * `text` - The markdown text to convert.
+* `jsonify` - Whether to JSON format the output string. Useful if it is going
+to be directly used as part of the
+[slackapi/slack-github-action](https://github.com/marketplace/actions/slack-send)
+payload. `true` by default.
 
 ### Outputs
 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
   text:
     description: 'Markdown text to convert'
     required: true
+  jsonify:
+    description: 'Whether to stringify the output as a JSON string'
+    required: false
+    default: 'true'
 outputs:
   text:
     description: 'Converted Slack mrkdwn text'

--- a/index.js
+++ b/index.js
@@ -3,8 +3,10 @@ const slackifyMarkdown = require('slackify-markdown');
 
 try {
     const input = core.getInput('text', { required: true });
+    const jsonify = core.getBooleanInput('jsonify', { required: false });
     const mrkdwn = slackifyMarkdown(input);
-    const output = mrkdwn.replace(/\r\n|\r|\n/g, "\\n");
+    // trim start/end " from JSON string for backwards compatibility
+    const output = jsonify ? JSON.stringify(mrkdwn).replace(/^"+|"+$/g, '') : mrkdwn;
     core.setOutput("text", output);
 } catch (error) {
     core.setFailed(error.message);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "slackify-markdown-action",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "slackify-markdown-action",
-      "version": "1.0.1",
+      "version": "1.1.0",
       "license": "MIT",
       "dependencies": {
         "@actions/core": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "slackify-markdown-action",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "GitHub Action to convert markdown into Slack's mrkdwn.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
## ℹ️ About

<!-- Describe your changes here ;) -->
First of all, thanks for building this very handy action! 🙇 

While adding it to our workflows, I realised I couldn't fully use it correctly due to the way newlines are encoded in the output. Similar to what @bachiri [reported](https://github.com/LoveToKnow/slackify-markdown-action/pull/12/files#r1310488091), I am not sure just replacing the newlines as introduced in #9 does the job. There are other characters that could interfere with the JSON format, so I guess the more robust option would be to `JSON.stringify()` the output. This should make sure `\n` is encoded as necessary, as well as any other character.

Let me know your thoughts!

I've also bumped the version string in the lockfiles to `1.1.0`, let me know if you'd rather have a different numbering.

---

- [ ] Has 🧪 tests
- [x] Has 📖 documentation

Fixes #8 