### PR TITLE
Revert breaking change on new line

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,7 +35,15 @@ jobs:
         shell: bash
         env:
           ACTUAL: ${{ steps.convert.outputs.text }}
-          EXPECTED: '*Heading 1*\n\n*Heading 2*\n\n<http://example.com|Link>\n\n•   List Item 1\n•   List Item 2\n'
+          EXPECTED: |
+            *Heading 1*
+
+            *Heading 2*
+
+            <http://example.com|Link>
+
+            •   List Item 1
+            •   List Item 2
         run: |
           if [ "$ACTUAL" != "$EXPECTED" ]; then
             echo "Actual: '$ACTUAL'"
@@ -55,7 +63,7 @@ jobs:
         id: release
         uses: cycjimmy/semantic-release-action@v2
         with:
-          semantic_version: 19       
+          semantic_version: 19
           extra_plugins: |
             @semantic-release/changelog
             @semantic-release/git

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const slackifyMarkdown = require('slackify-markdown');
 try {
     const input = core.getInput('text', { required: true });
     const mrkdwn = slackifyMarkdown(input);
-    const output = mrkdwn.replace(/\r\n|\r|\n/g, "\\n");
+    const output = mrkdwn.replace(/\r\n|\r|\n/g, "\n");
     core.setOutput("text", output);
 } catch (error) {
     core.setFailed(error.message);


### PR DESCRIPTION
## ℹ️ About

Hi @JoshCoady, the PR https://github.com/LoveToKnow/slackify-markdown-action/pull/9 introduce by @denis-trofimov was a breaking change:
- As shown by the failing test in https://github.com/LoveToKnow/slackify-markdown-action/pull/12
- As reported by @bachiri here https://github.com/LoveToKnow/slackify-markdown-action/pull/12#discussion_r1310488091
- As reported by @hasier https://github.com/LoveToKnow/slackify-markdown-action/pull/15

I encountered this breaking change, bumping from 1.0.1 to 1.0.2 give the result:
- from
<img width="666" alt="image" src="https://github.com/LoveToKnow/slackify-markdown-action/assets/9052536/67aac210-177a-4ea9-b1a8-faa4125b0804">
- to
<img width="649" alt="image" src="https://github.com/LoveToKnow/slackify-markdown-action/assets/9052536/8ea37f9b-0830-4a6f-a2b6-0b0ed2d86a68">

By escaping the `\n` they are not correctly interpreted by Slack anymore.

This is my github actions:
```
            -   name: Convert changelog's Markdown to mrkdwn
                id: changelog
                uses: LoveToKnow/slackify-markdown-action@v1.1.0
                with:
                    text: ${{ github.event.release.body }}

            -   name: Post to a Slack channel
                id: slack
                uses: slackapi/slack-github-action@v1.26.0
                with:
                    channel-id: 'deploy'
                    payload: | 
                        {
                            "blocks": [
                        		{
                                    "type": "header",
                                    "text": {
                                        "type": "plain_text",
                                        "text": "A new version has been deployed to prod! Make the world a better place!"
                                    }
                                },
                                {
                                    "type": "section",
                                    "text": {
                                        "type": "mrkdwn",
                                        "text": ${{ toJSON(steps.changelog.outputs.text) }}
                                    }
                                }
                            ]
                        }
```

I agree with @hasier the right way is to Jsonify the payload, this is what we were doing.
- You can do it, manually in the github actions `toJSON`
- You can do it inside the lib with an option like https://github.com/LoveToKnow/slackify-markdown-action/pull/15

I would say that @denis-trofimov missed this part, his PR manually escape the `\n` character cause he had trouble with, but the same issue could occur with some other character and not, the github actions leave us with a broken state where 
- Using toJSON break the `\n` 
- Not using toJson break with some other character we need to escape

I let
```
mrkdwn.replace(/\r\n|\r|\n/g, "\n");
```
to use the correct line delimiter, because I think it still can be an improvement ; but I removed the escaping.

Thanks 
---

- [x] Has 🧪 tests
- [ ] Has 📖 documentation

<!-- Add the link to the Jira ticket inside the parentheses -->
<!-- example: https://lovetoknow.atlassian.net/browse/<related-ticket> -->

- [🎫 Related Ticket](https://lovetoknow.atlassian.net/browse/) 

<!-- Remember you can override this template by creating a `.github/PULL_REQUEST_TEMPLATE.md` in your repository. The template you're seeing is in the https://github.com/LoveToKnow/.github repository -->
